### PR TITLE
Fix failures when creating `OctetString()` of type `bytes`.

### DIFF
--- a/src/snmp_agent/snmp.py
+++ b/src/snmp_agent/snmp.py
@@ -389,7 +389,7 @@ class SNMP(object):
             for item in value:
                 items.append(self._to_primitive(item))
             return items
-        elif isinstance(value, (int, str, bool)) or value is None:
+        elif isinstance(value, (int, str, bool, bytes)) or value is None:
             return value
         else:
             _dict = {}


### PR DESCRIPTION
`bytes` type doesn't have `__dict__` as shown here:

```python
>>> import sys
>>> sys.version
'3.9.10 (main, Jan 15 2022, 11:48:15) \n[Clang 12.0.0 (clang-1200.0.32.29)]'
>>> a = bytes.fromhex('001122334455')
>>> type(a)
<class 'bytes'>
>>> vars(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: vars() argument must have __dict__ attribute
```

Here is the error i was getting
```
future: <Task finished name='Task-18' coro=<SNMPProtocol._handle() done, defined at venv/lib/python3.9/site-packages/snmp_agent/server.py:22> exception=TypeError('vars() argument must have __dict__ attribute')>
Traceback (most recent call last):
  File "venv/lib/python3.9/site-packages/snmp_agent/server.py", line 37, in _handle
    logger.debug(f"Responded: {res.to_dict()}")
  File "venv/lib/python3.9/site-packages/snmp_agent/snmp.py", line 378, in to_dict
    dict_ = self._to_primitive(self)
  File "venv/lib/python3.9/site-packages/snmp_agent/snmp.py", line 397, in _to_primitive
    _dict[k] = self._to_primitive(v)
  File "venv/lib/python3.9/site-packages/snmp_agent/snmp.py", line 390, in _to_primitive
    items.append(self._to_primitive(item))
  File "venv/lib/python3.9/site-packages/snmp_agent/snmp.py", line 397, in _to_primitive
    _dict[k] = self._to_primitive(v)
  File "venv/lib/python3.9/site-packages/snmp_agent/snmp.py", line 397, in _to_primitive
    _dict[k] = self._to_primitive(v)
  File "venv/lib/python3.9/site-packages/snmp_agent/snmp.py", line 396, in _to_primitive
    for k, v in vars(value).items():
TypeError: vars() argument must have __dict__ attribute
```

This change solves the issue for me.